### PR TITLE
How tos section in project site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,10 +70,10 @@ prose:
           element: "text"
           label: "Permalink"
           value: ""
-      - name: "wiki"
+      - name: "howtos"
         field:
           element: "checkbox"
-          label: "wiki"
+          label: "howtos"
           value: false
       - name: "published"
         field:

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 title: windows dashboard admin
 email: ml-flyvemdm@teclib.com
 twitter: flyvemdm
-baseurl: "/windows-dashboard-admin"
+baseurl: "/windows-mdm-dashboard"
 url: "http://flyve.org"   
-image: http://flyve.org/windows-dashboard-admin/images/logo2.png
+image: http://flyve.org/windows-mdm-dashboard/images/logo2.png
 
 # Build settings
 markdown: kramdown
@@ -13,7 +13,7 @@ plugins:
   - jekyll-feed
   - jekyll-sitemap
 
-repository: flyve-mdm/windows-dashboard-admin
+repository: flyve-mdm/windows-mdm-dashboard
 
 prose:
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -37,7 +37,7 @@
                         </li>
                         
                         <li>
-                            <a class="color-type-secondary" href="{{ '/wiki' | absolute_url }}">Wiki</a>
+                            <a class="color-type-secondary" href="{{ '/howtos' | absolute_url }}">How-tos</a>
                         </li>
 
                         <li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,8 +14,8 @@ layout: default
 </div>
 
 <p class="goHome container">
-  {% if page.wiki %}
-    <a href="{{ "wiki" | absolute_url }}">
+  {% if page.howtos %}
+    <a href="{{ "howtos" | absolute_url }}">
   {% else %}
     <a href="{{ "news" | absolute_url }}">
   {% endif %}

--- a/howtos/index.html
+++ b/howtos/index.html
@@ -2,11 +2,11 @@
 layout: container
 ---
 
-<h2>Wiki</h2>
+<h2>How tos</h2>
 
 {% assign articles = site.posts %}
 {% for article in articles %}
-    {% if article.wiki %}
+    {% if article.howtos %}
         <div class="article-wiki">
             <h3>
                 <a class="post-link" href="{{ article.url | absolute_url }}">{{ article.title | escape }}</a>

--- a/news.html
+++ b/news.html
@@ -6,7 +6,7 @@ layout: page
   <h1>News post</h1>
   <ul class="post-list">
       {% for post in site.posts %}
-        {% if post.wiki != true %}
+        {% if post.howtos != true %}
           <li>
             {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
             <span class="post-meta">{{ post.date | date: date_format }}</span>


### PR DESCRIPTION
Hi

This PR changes the following

* The Project site url according to the repo name
* The wiki section to How-tos 